### PR TITLE
Update gdth.go

### DIFF
--- a/cmd/gdth/gdth.go
+++ b/cmd/gdth/gdth.go
@@ -12,6 +12,11 @@ func main() {
 	outputMode := flag.String("format", "table", "Output mode. Options: table, csv")
 	flag.Parse()
 
+	     if flag.NArgs() < 1{
+     	flag.Usage()
+     	os.Exit(1)
+     }
+	
 	inputHash := flag.Arg(0)
 	results := gdth.Detect(inputHash)
 


### PR DESCRIPTION
Added empty input check to the cmd/gdth/gdth.go
This check is to print usage of the tool when there's no arguments
-h or -help is now made available due to this check